### PR TITLE
Add DBs Password to the payload to allow importing dashboards with passwords

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+INPUT_URL_BASE=http://localhost:8088
+INPUT_DASHBOARD_FILE_PATH=/dashboard.zip
+INPUT_OVERWRITE=true
+SUPERSET_USERNAME=test
+SUPERSET_PASSWORD=testpass
+DBS_PASSWORDS="{"MyDatabase": "my_password"}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dashboard.zip
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9.13
 
 COPY requirements.txt /
 RUN /usr/local/bin/python -m pip install --upgrade pip && \
-  pip3 install --no-cache-dir -r /requirements.txt
+  pip install --no-cache-dir -r /requirements.txt
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY import_dashboard.py /import_dashboard.py

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Import Superset Dashboard Action
 
 This action imports a dashboard from local path ZIP file to Superset
-This action expects to have 2 additional environment variables inside the workflow
+This action expects to have 3 additional environment variables inside the workflow
 
-1. `SUPERSET_USERNAME`
-2. `SUPERSET_PASSWORD`
+1. `SUPERSET_USERNAME` - Your username for Superset
+2. `SUPERSET_PASSWORD` - Your password for Superset
+3. `DBS_PASSWORDS` - JSON map of passwords for each featured DB in the dashboard. For example, if the dashboard includes a database config for MyDatabase, the password should be provided in the following format: {"MyDatabase": "my_password"}. If no DB required, the default will be {}
 
 ## Inputs
 ### `url_base`
 **Required** Base URL for your Superset API endpoint. Default: `http://localhost:8088`
 
 ### `dashboard_file_path`
-**Required** Path of the dashboard you want to import. 
+**Required** Path of the dashboard you want to import.
+
+### `overwrite`
+**Not Required** Boolean index if to allow overwriting an existing dashboard or not. Default: `true`
 
 ## Example usage
 ```
@@ -19,6 +23,7 @@ uses: actions/import-superset-dashboard-action@v1
 with:
   url-base: http://localhost:8088
   dashboard_file_path: dashboard.zip
+  overwrite: true
 ```
 
 ## Example Workflow
@@ -33,10 +38,12 @@ on:
 env:
   SUPERSET_USERNAME: test
   SUPERSET_PASSWORD: testpass
+  DBS_PASSWORDS: {"MyDatabase": "my_password"}
 
 jobs:
   uses: actions/import-superset-dashboard-action@v1
   with:
-    url-base: http://localhost:8088
+    url_base: http://localhost:8088
     dashboard_file_path: dashboard.zip
+    overwrite: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,13 +7,18 @@ inputs:
     required: true
     default: 'http://localhost:8088'
   dashboard_file_path: 
-    description: Path of the dashboard you want to import
+    description: 'Path of the dashboard you want to import'
     required: true
+  overwrite:
+    description: 'Boolean index if to allow overwriting an existing dashboard or not'
+    required: false
+    default: true
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.url_base }}
     - ${{ inputs.dashboard_file_path }}
+    - ${{ inputs.overwrite }}
 branding:
   color: blue

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  importer:
+    image: import-dashboard:latest
+    build: .
+    volumes:
+      - ./dashboard.zip:/dashboard.zip
+    env_file:
+      - ".env"
+    command: sleep infinity

--- a/import_dashboard.py
+++ b/import_dashboard.py
@@ -3,6 +3,7 @@ import requests.exceptions
 import requests_oauthlib
 import urllib.parse
 from os import path, getenv
+import json as js
 
 def login_superset():
     """
@@ -10,25 +11,30 @@ def login_superset():
 
     Returns: Login token (Bearer) and Session object
     """
-    print('Start Superset authentication')
-    # Login
-    login_endpoint = urllib.parse.urljoin(URL_BASE, '/api/v1/security/login')
-    response = requests.post(
-        login_endpoint,
-        json={
-            "username": getenv('SUPERSET_USERNAME'),
-            "password": getenv('SUPERSET_PASSWORD'),
-            "provider": 'db',
-            "refresh": "true",
-        },
-    )
+    try:
+        print('Start Superset authentication')
+        # Login
+        login_endpoint = urllib.parse.urljoin(URL_BASE, '/api/v1/security/login')
+        response = requests.post(
+            login_endpoint,
+            json={
+                "username": getenv('SUPERSET_USERNAME'),
+                "password": getenv('SUPERSET_PASSWORD'),
+                "provider": 'db',
+                "refresh": "true",
+            },
+        )
 
-    login_token = response.json()
+        login_token = response.json()
 
-    # Create session
-    session = requests_oauthlib.OAuth2Session(token=login_token)
-    print('Session created successfully')
+        # Create session
+        session = requests_oauthlib.OAuth2Session(token=login_token)
+        print('Session created successfully')
+    except Exception as e:
+        print(f'Failed login Superset: {e}')
+        raise(e)
     return login_token, session
+
 
 def get_csrf_token(session):
     """
@@ -39,17 +45,40 @@ def get_csrf_token(session):
     
     Returns: CSRF token
     """
-    print('Start request to retrieve CSRF token')
-    # Get CSRF Token
-    csrf_endpoint = urllib.parse.urljoin(URL_BASE, '/api/v1/security/csrf_token/')
-    headers={"Referer": csrf_endpoint}
-    csrf_response = session.get(
-        url=csrf_endpoint,
-        headers=headers
-    )
-    csrf_token = csrf_response.json().get("result")
-    print('CSRF token received succesfully')
+    try:
+        print('Start request to retrieve CSRF token')
+        # Get CSRF Token
+        csrf_endpoint = urllib.parse.urljoin(URL_BASE, '/api/v1/security/csrf_token/')
+        headers={"Referer": csrf_endpoint}
+        csrf_response = session.get(
+            url=csrf_endpoint,
+            headers=headers
+        )
+        csrf_token = csrf_response.json().get("result")
+        print('CSRF token received succesfully')
+    except Exception as e:
+        print(f'Failed creating the CSRF token: {e}')
+        raise(e)
     return csrf_token
+
+
+def create_passwords_string() -> str:
+    """
+    Generate the passwords string for the payload
+
+    Returns: String mappign the DBs and their passwords
+    """
+    try:
+        DBS_PASSWORDS = getenv('DBS_PASSWORDS', {})
+        pass_map = js.loads(DBS_PASSWORDS)
+        pass_dict = {f"databases/{k}.yaml": v for k, v in pass_map.items()}
+
+        passwords_string = str(pass_dict)
+        return passwords_string
+    except Exception as e:
+        print(f'Failed creating the password string: {e}')
+        raise(e)
+    
 
 def import_dashboard(session, login_token, csrf_token):
     """
@@ -60,36 +89,47 @@ def import_dashboard(session, login_token, csrf_token):
         login_token -- Bearer token for the API request
         csrf_token -- CSRF token for the API request
     """
-    container_dashboard_path = path.join('/', 'github', 'workspace', DASHBOARD_FILE_PATH)
-    print(f'Start importing the dashboard from {container_dashboard_path}')
-    # Import dashboard
-    import_endpoint = urllib.parse.urljoin(URL_BASE, '/api/v1/dashboard/import/')
+    try:
+        container_dashboard_path = path.join('/', 'github', 'workspace', DASHBOARD_FILE_PATH)
+        print(f'Start importing the dashboard from {container_dashboard_path}')
+        # Import dashboard
+        import_endpoint = urllib.parse.urljoin(URL_BASE, '/api/v1/dashboard/import/')
 
-    headers = {
-        'accept': 'application/json',
-        'Authorization': f'Bearer {login_token}',
-        'X-CSRFToken': csrf_token,
-        'Referer': import_endpoint
-    }
+        headers = {
+            'accept': 'application/json',
+            'Authorization': f'Bearer {login_token}',
+            'X-CSRFToken': csrf_token,
+            'Referer': import_endpoint
+        }
 
-    files = { 
-    'formData': (
-        container_dashboard_path, 
-        open(container_dashboard_path, 'rb'), 
-        'application/json'
-        )
-    }
+        files = { 
+        'formData': (
+            container_dashboard_path, 
+            open(container_dashboard_path, 'rb'), 
+            'application/json'
+            )
+        }
 
-    payload = {"overwrite":'true'}
+        OVERWRITE = getenv('OVERWRITE', True)
+        overwrite_payload = str(OVERWRITE).lower()
+        payload = {"overwrite": overwrite_payload}
 
-    response = session.post(
-                url=import_endpoint, 
-                headers=headers,
-                files=files,
-                data=payload
-        )
-    assert response.status_code == 200, f'Error in importing the dashboard\n{response}'
-    print(f'Dashboard imported succesfully from {container_dashboard_path}')
+        # DBS Passwords
+        passwords_string = create_passwords_string()
+        if len(passwords_string) > 2:   # Only if there is at least 1 DB password
+            payload["passwords"] = passwords_string
+
+        response = session.post(
+                    url=import_endpoint, 
+                    headers=headers,
+                    files=files,
+                    data=payload
+            )
+        assert response.status_code == 200, f'Error in importing the dashboard\n{response}'
+        print(f'Dashboard imported succesfully from {container_dashboard_path}')
+    except Exception as e:
+        print(f'Failed importing the dashboard: {e}')
+        raise(e)
 
 def main():
     login_token, session = login_superset()


### PR DESCRIPTION
As described in Superset API docs, if the dashboard is based on a DB which includes a password (most of the times), these passwords should be added to the payload.

This PR adds them as an environment variable and use them in the payload